### PR TITLE
Refactor: Register on-exit listeners only if method is used 1.0.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.7
+- refactor: register on-exit listeners only if method is used
+
 # 1.0.6
 - feature: add CURRENCIES and WALLET_TYPES datasets
 - refactor: improve verbosity of catch-uncaught handler

--- a/lib/on_exit.js
+++ b/lib/on_exit.js
@@ -35,11 +35,20 @@ const onExit = (err, type) => {
   })
 }
 
-process.on('exit', (err) => onExit(err, 'exit'))
-process.on('SIGINT', (err) => onExit(err, 'SIGINT'))
-process.on('SIGUSR1', (err) => onExit(err, 'SIGUSR1'))
-process.on('SIGUSR2', (err) => onExit(err, 'SIGUSR2'))
-process.on('uncaughtException', (err) => onExit(err, 'uncaughtException'))
+let listenersRegistered = false
+const registerOnExitListeners = () => {
+  if (listenersRegistered) {
+    return
+  }
+
+  process.on('exit', (err) => onExit(err, 'exit'))
+  process.on('SIGINT', (err) => onExit(err, 'SIGINT'))
+  process.on('SIGUSR1', (err) => onExit(err, 'SIGUSR1'))
+  process.on('SIGUSR2', (err) => onExit(err, 'SIGUSR2'))
+  process.on('uncaughtException', (err) => onExit(err, 'uncaughtException'))
+
+  listenersRegistered = true
+}
 
 /**
  * Registers a callback to be executed upon application exit (including
@@ -53,6 +62,10 @@ const registerExitCallback = (cb, priority = 0) => {
 
   callbacks.push(cb)
   callbacks.sort((a, b) => b._p - a._p)
+
+  if (!listenersRegistered) {
+    registerOnExitListeners()
+  }
 }
 
 module.exports = registerExitCallback

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-util",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "HF utilities",
   "main": "./dist/index.js",
   "directories": {


### PR DESCRIPTION
Refactors `onExit()` to only register exit callbacks if the method itself is used; otherwise it may clobber `lib/catch_uncaught_exit`'s behavior by calling `process.exit()` before `stackman` has a chance to generate a trace.