### PR TITLE
Fix: Add Missing Bluebird to Manifest 1.0.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.8
+- fix: add missing bluebird dep to manifest
+
 # 1.0.7
 - refactor: register on-exit listeners only if method is used
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-util",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "HF utilities",
   "main": "./dist/index.js",
   "directories": {
@@ -36,6 +36,7 @@
     "@babel/preset-es2015": "^7.0.0-beta.53",
     "@babel/preset-stage-0": "^7.0.0",
     "babel-eslint": "^7.2.2",
+    "bluebird": "^3.7.2",
     "copy": "^0.3.1",
     "create-index": "^2.3.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
Closes #8