### PR TITLE
Feature: Allow catchUncaughtError logger override 1.0.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.9
+- feature: allow catchUncaughtError logger override
+
 # 1.0.8
 - fix: add missing bluebird dep to manifest
 

--- a/lib/catch_uncaught_errors.js
+++ b/lib/catch_uncaught_errors.js
@@ -2,6 +2,8 @@
 
 const stackman = require('stackman')()
 
+let logger = console.error
+
 const onError = (incomingError) => {
   stackman.callsites(incomingError, (err, callsites) => {
     if (err) {
@@ -15,18 +17,18 @@ const onError = (incomingError) => {
             return
           }
 
-          console.info('')
-          console.info('source from %s:%s', cs.getFileName(), cs.getLineNumber())
-          console.info(ctx.pre.join('\n'))
-          console.info('!!!')
-          console.info(ctx.line)
-          console.info('!!!')
-          console.info(ctx.post.join('\n'))
+          logger('')
+          logger('source from %s:%s', cs.getFileName(), cs.getLineNumber())
+          logger(ctx.pre.join('\n'))
+          logger('!!!')
+          logger(ctx.line)
+          logger('!!!')
+          logger(ctx.post.join('\n'))
         })
       }
 
-      console.error(
-        '! %s -> %s (%s) [%s:%d]',
+      logger(
+        '! %s -> %s (%s) [%s:%s]',
         cs.getFunctionNameSanitized(), cs.getTypeNameSafely(),
         cs.getFileName(), cs.getLineNumber()
       )
@@ -34,12 +36,14 @@ const onError = (incomingError) => {
   })
 }
 
-process.on('unhandledRejection', (reason, p) => {
-  console.error('Unhandled rejection: %s', reason instanceof Error ? reason.message : reason)
+process.on('unhandledRejection', (reason) => {
+  logger('Unhandled rejection: %s', reason instanceof Error ? reason.message : reason)
   onError(reason instanceof Error ? reason : new Error(reason))
 }).on('uncaughtException', err => {
-  console.error('Uncaught exception: %s', err.message)
+  logger('Uncaught exception: %s', err.message)
   onError(err)
 })
 
-module.exports = {}
+module.exports = {
+  setLogger: l => { logger = l }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-util",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "HF utilities",
   "main": "./dist/index.js",
   "directories": {


### PR DESCRIPTION
Small change, `lib/catch_uncaught_errors` now exports a `setLogger` function. Defaults to `console.error`